### PR TITLE
fixed ifc_req struct assignment

### DIFF
--- a/ext/network_interface_ext/netifaces.c
+++ b/ext/network_interface_ext/netifaces.c
@@ -677,7 +677,7 @@ rbnetifaces_s_interfaces (VALUE self)
     return Qnil;
   }
 
-  *pfreq = ifc.CNAME(ifc_req);
+  pfreq = ifc.CNAME(ifc_req);
 
   for (n = 0; n < ifc.CNAME(ifc_len)/sizeof(struct CNAME(ifreq));n++,pfreq++)
   {


### PR DESCRIPTION
```
netifaces.c:680:10: error: incompatible types when assigning to type 'struct ifreq' from type 'struct ifreq *'
```

field `ifreq` in the `ifconfig` struct is of type `struct ifreq *` not `struct ifreq`.

tested on bionic libc.

hope this helps.
