### PR TITLE
Fix compile error when building network_interface gem within termux

### DIFF
--- a/ext/network_interface_ext/netifaces.h
+++ b/ext/network_interface_ext/netifaces.h
@@ -30,6 +30,7 @@
 /* For Linux, include all the sockaddr
    definitions we can lay our hands on. */
 #if !HAVE_SOCKADDR_SA_LEN
+#    include <netinet/in.h>
 #  if HAVE_NETASH_ASH_H
 #    include <netash/ash.h>
 #  endif


### PR DESCRIPTION
This fixes a bug where the `gem install network_interface` fails within termux (https://play.google.com/store/apps/details?id=com.termux) on Android.
https://github.com/termux/termux-packages/issues/715