### PR TITLE
Add github actions and address deprecation warnings

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,57 @@
+name: Verify
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+        test_cmd:
+          - bundle exec rspec
+
+    env:
+      RAILS_ENV: test
+
+    name: Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Setup bundler
+        run: |
+          gem install bundler
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: ${{ matrix.test_cmd }}
+        run: |
+          echo "${CMD}"
+          bash -c "${CMD}"
+        env:
+          CMD: ${{ matrix.test_cmd }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 40
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ruby:
           - 2.5
@@ -49,6 +49,7 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
+          bundle exec rake compile
       - name: ${{ matrix.test_cmd }}
         run: |
           echo "${CMD}"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 40
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         ruby:
           - 2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,33 +6,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.3)
-    rake (12.0.0)
-    rake-compiler (1.0.4)
+    diff-lcs (1.4.4)
+    rake (13.0.3)
+    rake-compiler (1.1.1)
       rake
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-mocks (3.6.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
-  bundler (~> 1.3)
   network_interface!
   rake
   rake-compiler
   rspec
 
 BUNDLED WITH
-   1.15.4
+   2.2.9

--- a/network_interface.gemspec
+++ b/network_interface.gemspec
@@ -22,8 +22,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rake-compiler", ">= 0"
+  spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "rspec"
 end

--- a/spec/netiface_spec.rb
+++ b/spec/netiface_spec.rb
@@ -4,7 +4,7 @@ describe NetworkInterface do
 
   describe "#interfaces" do
     it "should have the same interfaces as the system_interfaces" do
-      NetworkInterface.interfaces.should include(*system_interfaces_with_addresses.keys)
+      expect(NetworkInterface.interfaces).to include(*system_interfaces_with_addresses.keys)
     end
   end
   
@@ -14,30 +14,30 @@ describe NetworkInterface do
         if hash.has_key?(:ipv4)
           describe "ipv4" do
             it "should have an ipv4 address" do
-              NetworkInterface.addresses(interface).should have_key NetworkInterface::AF_INET
+              expect(NetworkInterface.addresses(interface)).to have_key NetworkInterface::AF_INET
             end
             it "should match the system interface of #{hash[:ipv4]}" do
-              NetworkInterface.addresses(interface)[NetworkInterface::AF_INET][0]["addr"].should == hash[:ipv4]
+              expect(NetworkInterface.addresses(interface)[NetworkInterface::AF_INET][0]["addr"]).to eq hash[:ipv4]
             end
           end
         end
         if hash.has_key?(:ipv6)
           describe "ipv6" do
             it "should have an ipv6 address" do
-              NetworkInterface.addresses(interface).should have_key NetworkInterface::AF_INET6
+              expect(NetworkInterface.addresses(interface)).to have_key NetworkInterface::AF_INET6
             end
             it "should match the system interface of #{hash[:ipv6]}" do
-              NetworkInterface.addresses(interface)[NetworkInterface::AF_INET6][0]["addr"].should == hash[:ipv6]
+              expect(NetworkInterface.addresses(interface)[NetworkInterface::AF_INET6][0]["addr"]).to eq hash[:ipv6]
             end
           end          
         end
         if hash.has_key?(:mac)
           describe "MAC address" do
             it "should have a MAC address" do
-              NetworkInterface.addresses(interface).should have_key NetworkInterface::AF_LINK
+              expect(NetworkInterface.addresses(interface)).to have_key NetworkInterface::AF_LINK
             end
             it "should match the system interface of #{hash[:mac]}" do
-              NetworkInterface.addresses(interface)[NetworkInterface::AF_LINK][0]["addr"].should == hash[:mac]
+              expect(NetworkInterface.addresses(interface)[NetworkInterface::AF_LINK][0]["addr"]).to eq hash[:mac]
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'lib'))
 require 'network_interface'
 require 'rspec'
-require 'rspec/autorun'
 
 RSpec.configure do |config|
 end


### PR DESCRIPTION
Added a github action for running the tests and also addressed some deprecation warnings from RSpec but nothing was related to the ruby 3 effort (https://github.com/rapid7/metasploit-framework/issues/14666) which all seemed fine

Test run available here: https://github.com/dwelch-r7/network_interface/actions/runs/558495863

Sidenote: tests don't all pass on my machine, but they do on GH actions so I think it's an environment issue