### PR TITLE
Upversion Github actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,7 +32,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }} ${{ matrix.docker_image && 'Docker' || matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         if: ${{ !matrix.docker_image }}


### PR DESCRIPTION
This PR upversions the github actions, from `actions/checkout@v2` to `actions/checkout@v4`.

v2 ran on Node.js 16, which is deprecated by Github. Runs using v2 have a deprecation warning, as can be viewed at the bottom of https://github.com/rapid7/network_interface/actions/runs/6405498223

 v4 runs on Node.js 20, which clears these deprecation warnings. An example of the warnings being cleared can be found at https://github.com/KanchiMoe/network_interface/actions/runs/9025237108

More information on this can be found at https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.